### PR TITLE
Remove records in Airatable for test

### DIFF
--- a/airtable_client.py
+++ b/airtable_client.py
@@ -45,6 +45,9 @@ class AirtableClient:
         Args:
             field_name (str): Airtable field names.
             field_value (str): The values corresponding to the field names in Airtable.
+
+        Returns:
+            Airtable API response (dict): Dictionary of successful or unsuccessful deletions and IDs of items.
         """
 
         try:

--- a/airtable_client.py
+++ b/airtable_client.py
@@ -52,6 +52,3 @@ class AirtableClient:
         except KeyError as ke:
             app.logger.error(ke)
             raise ke
-        except TypeError as te:
-            app.logger.error(te)
-            raise te

--- a/airtable_client.py
+++ b/airtable_client.py
@@ -37,18 +37,18 @@ class AirtableClient:
             app.logger.error(te)
             raise te
 
-    def delete_asset(self, airtable_id: str):
+    def delete_asset(self, field_name: str, field_value: str):
         """Delete Airtable asset.
 
-        Remove the specified item with the ID of the item registered in Airtable as an argument.
+        Remove the specified field name and the value registered in Airtable as arguments.
 
         Args:
-            airtable_id (str): ID registered with Airtable.
-
+            field_name (str): Airtable field names.
+            field_value (str): The values corresponding to the field names in Airtable.
         """
 
         try:
-            return self.airtable_client.delete(airtable_id)
+            return self.airtable_client.delete_by_field(field_name, field_value)
         except requests.exceptions.HTTPError as he:
             app.logger.error(he)
             raise he

--- a/airtable_client.py
+++ b/airtable_client.py
@@ -36,3 +36,22 @@ class AirtableClient:
         except TypeError as te:
             app.logger.error(te)
             raise te
+
+    def delete_asset(self, airtable_id: str):
+        """Delete Airtable asset.
+
+        Remove the specified item with the ID of the item registered in Airtable as an argument.
+
+        Args:
+            airtable_id (str): ID registered with Airtable.
+
+        """
+
+        try:
+            return self.airtable_client.delete(airtable_id)
+        except requests.exceptions.HTTPError as he:
+            app.logger.error(he)
+            raise he
+        except TypeError as te:
+            app.logger.error(te)
+            raise te

--- a/airtable_client.py
+++ b/airtable_client.py
@@ -37,21 +37,20 @@ class AirtableClient:
             app.logger.error(te)
             raise te
 
-    def delete_asset(self, field_name: str, field_value: str):
+    def delete_asset_by_title(self, value: str):
         """Delete Airtable asset.
 
-        Remove the specified field name and the value registered in Airtable as arguments.
+        Deletes the equipment registered in the Airtable with the value of the title field as an argument.
 
         Args:
-            field_name (str): Airtable field names.
-            field_value (str): The values corresponding to the field names in Airtable.
+            value (str): The values corresponding to the title-field in Airtable.
 
         Returns:
             Airtable API response (dict): Dictionary of successful or unsuccessful deletions and IDs of items.
         """
 
         try:
-            return self.airtable_client.delete_by_field(field_name, field_value)
+            return self.airtable_client.delete_by_field("title", value)
         except KeyError as ke:
             app.logger.error(ke)
             raise ke

--- a/airtable_client.py
+++ b/airtable_client.py
@@ -49,9 +49,9 @@ class AirtableClient:
 
         try:
             return self.airtable_client.delete_by_field(field_name, field_value)
-        except requests.exceptions.HTTPError as he:
-            app.logger.error(he)
-            raise he
+        except KeyError as ke:
+            app.logger.error(ke)
+            raise ke
         except TypeError as te:
             app.logger.error(te)
             raise te

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -42,8 +42,9 @@ def test_check_asset_instance(airtable_client):
 def test_register_asset_and_delete_asset_success(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
-    assert airtable_client.register_asset(registerable_asset)
-    assert airtable_client.delete_asset("title", registerable_asset.title)
+    register_asset = airtable_client.register_asset(registerable_asset)
+    assert register_asset
+    assert airtable_client.airtable_client.delete(register_asset["id"])
 
 
 def test_register_asset_with_non_existent_key_failure(airtable_client):
@@ -57,4 +58,4 @@ def test_delete_asset_failure(airtable_client):
     """Testing when removing non-existent items."""
 
     with pytest.raises(KeyError):
-        airtable_client.delete_asset("title", "test")
+        airtable_client.delete_asset_by_title("test")

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -46,7 +46,7 @@ def test_register(airtable_client):
     assert airtable_client.delete_asset("title", registerable_asset.title)
 
 
-def test_register_non_existent_key(airtable_client):
+def test_register_asset_with_non_existent_key_failure(airtable_client):
     """Testing an instance of the Airtable data class is an argument."""
 
     with pytest.raises(TypeError):

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -43,7 +43,7 @@ def test_register(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
     assert airtable_client.register_asset(registerable_asset)
-    assert airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
+    assert airtable_client.delete_asset("title", registerable_asset.title)
 
 
 def test_register_non_existent_key(airtable_client):

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -42,7 +42,9 @@ def test_check_asset_instance(airtable_client):
 def test_register(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
-    assert airtable_client.register_asset(registerable_asset)
+    register_asset = airtable_client.register_asset(registerable_asset)
+    airtable_client.delete_asset(register_asset["id"])
+    assert register_asset
 
 
 def test_register_non_existent_key(airtable_client):

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -43,7 +43,7 @@ def test_register(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
     assert airtable_client.register_asset(registerable_asset)
-    airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
+    # airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
 
 
 def test_register_non_existent_key(airtable_client):
@@ -51,3 +51,16 @@ def test_register_non_existent_key(airtable_client):
 
     with pytest.raises(TypeError):
         airtable_client.register_asset({"test": "test"})
+
+
+def test_delete_asset_success(airtable_client):
+    """Testing remove items with any field name and value."""
+
+    assert airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
+
+
+def test_delete_asset_failure(airtable_client):
+    """Testing when removing non-existent items."""
+
+    with pytest.raises(KeyError):
+        airtable_client.delete_asset("title", "test")

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -39,7 +39,7 @@ def test_check_asset_instance(airtable_client):
     assert registerable_asset.registered_at
 
 
-def test_register(airtable_client):
+def test_register_asset_and_delete_asset_success(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
     assert airtable_client.register_asset(registerable_asset)
@@ -47,7 +47,7 @@ def test_register(airtable_client):
 
 
 def test_register_asset_with_non_existent_key_failure(airtable_client):
-    """Testing an instance of the Airtable data class is an argument."""
+    """Testing when a non-existent key is registered."""
 
     with pytest.raises(TypeError):
         airtable_client.register_asset({"test": "test"})

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -43,7 +43,7 @@ def test_register(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
     assert airtable_client.register_asset(registerable_asset)
-    # airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
+    assert airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
 
 
 def test_register_non_existent_key(airtable_client):
@@ -51,12 +51,6 @@ def test_register_non_existent_key(airtable_client):
 
     with pytest.raises(TypeError):
         airtable_client.register_asset({"test": "test"})
-
-
-def test_delete_asset_success(airtable_client):
-    """Testing remove items with any field name and value."""
-
-    assert airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
 
 
 def test_delete_asset_failure(airtable_client):

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -42,9 +42,8 @@ def test_check_asset_instance(airtable_client):
 def test_register(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
-    register_asset = airtable_client.register_asset(registerable_asset)
-    airtable_client.delete_asset(register_asset["id"])
-    assert register_asset
+    assert airtable_client.register_asset(registerable_asset)
+    airtable_client.delete_asset("title", "PlayStation 5 (CFI-1000A01)")
 
 
 def test_register_non_existent_key(airtable_client):

--- a/tests/test_airtable_client.py
+++ b/tests/test_airtable_client.py
@@ -39,12 +39,23 @@ def test_check_asset_instance(airtable_client):
     assert registerable_asset.registered_at
 
 
-def test_register_asset_and_delete_asset_success(airtable_client):
+def test_register_asset_success(airtable_client):
     """Testing whether a dictionary with the proper field names can be registered correctly."""
 
-    register_asset = airtable_client.register_asset(registerable_asset)
-    assert register_asset
-    assert airtable_client.airtable_client.delete(register_asset["id"])
+    assert airtable_client.register_asset(registerable_asset)
+
+
+def test_delete_asset_by_title_success(airtable_client):
+    """Testing delete an Asset with the proper field name"""
+
+    assert airtable_client.delete_asset_by_title(registerable_asset.title)
+
+
+def test_delete_asset_by_title_failure(airtable_client):
+    """Testing when removing non-existent items."""
+
+    with pytest.raises(KeyError):
+        airtable_client.delete_asset_by_title("test")
 
 
 def test_register_asset_with_non_existent_key_failure(airtable_client):
@@ -52,10 +63,3 @@ def test_register_asset_with_non_existent_key_failure(airtable_client):
 
     with pytest.raises(TypeError):
         airtable_client.register_asset({"test": "test"})
-
-
-def test_delete_asset_failure(airtable_client):
-    """Testing when removing non-existent items."""
-
-    with pytest.raises(KeyError):
-        airtable_client.delete_asset_by_title("test")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,7 +88,7 @@ def test_POST_register_airtable_success(test_client):
     test_client.post("/registration", data={"asin": "B07XB5WX89"})
     response = test_client.post("/register_airtable", data=imd, follow_redirects=True)
     assert b"Registration completed!" in response.data
-    AirtableClient().delete_asset("title", imd.getlist(key="title")[0])
+    AirtableClient().delete_asset("asin", "B07XB5WX89")
 
 
 def test_POST_register_airtable_failure(test_client):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,7 +88,7 @@ def test_POST_register_airtable_success(test_client):
     test_client.post("/registration", data={"asin": "B07XB5WX89"})
     response = test_client.post("/register_airtable", data=imd, follow_redirects=True)
     assert b"Registration completed!" in response.data
-    AirtableClient().delete_asset("asin", "B07XB5WX89")
+    AirtableClient().delete_asset_by_title("テンマクデザイン サーカス TC DX")
 
 
 def test_POST_register_airtable_failure(test_client):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,9 +47,9 @@ def test_GET_registration_direct_access(test_client):
 
 
 def test_POST_registration_success(test_client):
-    test_client.get("/search?query=サーカスTC")
-    response = test_client.post("/registration", data={"asin": "B07XB5WX89"})
-    assert "Registration for details of テンマクデザイン サーカス TC DX" in response.data.decode("UTF-8")
+    test_client.get("/search?query=UNIX")
+    response = test_client.post("/registration", data={"asin": "4274064069"})
+    assert "Registration for details of UNIXという考え方―その設計思想と哲学" in response.data.decode("UTF-8")
 
 
 def test_POST_registration_failure(test_client):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import pytest
 from werkzeug.datastructures import ImmutableMultiDict
 
+from airtable_client import AirtableClient
 from main import app
 
 
@@ -87,6 +88,7 @@ def test_POST_register_airtable_success(test_client):
     test_client.post("/registration", data={"asin": "B07XB5WX89"})
     response = test_client.post("/register_airtable", data=imd, follow_redirects=True)
     assert b"Registration completed!" in response.data
+    AirtableClient().delete_asset("title", "テンマクデザイン サーカス TC DX")
 
 
 def test_POST_register_airtable_failure(test_client):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,7 +88,7 @@ def test_POST_register_airtable_success(test_client):
     test_client.post("/registration", data={"asin": "B07XB5WX89"})
     response = test_client.post("/register_airtable", data=imd, follow_redirects=True)
     assert b"Registration completed!" in response.data
-    AirtableClient().delete_asset("title", "テンマクデザイン サーカス TC DX")
+    AirtableClient().delete_asset("title", imd.getlist(key="title")[0])
 
 
 def test_POST_register_airtable_failure(test_client):


### PR DESCRIPTION
## Describe the PR

To close #25 .
Added the ability to remove items registered in the test.

## Screenshots

![fortest](https://user-images.githubusercontent.com/67737076/101624641-915b9580-3a5d-11eb-82fd-e3c9b085374a.gif)

## Detail of the change

### airtable_client.py

Create delete_asset method:

```airtable_client.py

def delete_asset_by_title(self, value: str):
    """Delete Airtable asset.

    Deletes the equipment registered in the Airtable with the value of the title field as an argument.

    Args:
        value (str): The values corresponding to the title-field in Airtable.

    Returns:
        Airtable API response (dict): Dictionary of successful or unsuccessful deletions and IDs of items.
    """
       
        ....

```

### test_main.py, test_airtable_client.py

Add the code to remove the registered items.

## Anticipated impacts

None.

## To reproduce

Steps to check the behavior:

1. Visit to [Airtable](https://airtable.com/tbl3fqXr9nJmLm8CM/viwc0kRm6kEoxk5EW?blocks=hide)
1. Check the initial state of the table items
1. Prepare `Python` environment
    `python3 -m venv venv`
    `source venv/bin/activate`
1. `pytest -vv .`
1. Check [Airtable](https://airtable.com/tbl3fqXr9nJmLm8CM/viwc0kRm6kEoxk5EW?blocks=hide) and make sure that the item is registered and deleted, as shown in the screenshot

## Additional context

None.
